### PR TITLE
Use render.ini template for POV-Ray configuration

### DIFF
--- a/assets/render.ini
+++ b/assets/render.ini
@@ -1,18 +1,32 @@
 # File: assets/render.ini
-; This file is included for reference - the actual .ini is generated programmatically
-Input_File_Name=mobius_scene.pov
-Output_File_Name=frame_
-Width=1280
-Height=720
-Antialias=On
-Antialias_Threshold=0.1
-Antialias_Depth=3
-Display=Off
-Pause_When_Done=Off
-Verbose=Off
+# Template used to generate render.ini files at runtime.
+Input_File_Name="@INPUT_FILE@"
+Output_File_Name="frame_"
+Output_File_Type=N
 
+Width=@WIDTH@
+Height=@HEIGHT@
+
+Antialias=On
+Antialias_Depth=3
+Sampling_Method=2
+Antialias_Threshold=0.05
+
+;; # +W1920 +H1080
++A0.1
++AM2 +R3
++Q09
++UA
+
+; === Animation settings ===
 Initial_Frame=1
-Final_Frame=150
-Initial_Clock=0.0
-Final_Clock=1.0
+Final_Frame=@FINAL_FRAME@
+Initial_Clock=0
+Final_Clock=1
 Cyclic_Animation=Off
+Pause_when_Done=Off
+
+; === Performance tuning ===
+Bounding=Off
+Display=Off
+Verbose=Off

--- a/src/MobiusSphereVisual.jl
+++ b/src/MobiusSphereVisual.jl
@@ -68,38 +68,19 @@ end
 Generate a minimal, robust .ini file.
 """
 function generate_pov_ini(output_dir::String, nframes::Int, resolution::Tuple{Int,Int})
-    ini_content = """
-Input_File_Name="mobius.pov"
-Output_File_Name="frame_"
-Output_File_Type=N ; PNG, numbered as frame_0001.png, frame_0002.png, ...
+    template_path = joinpath(ASSETS_DIR, "render.ini")
+    if !isfile(template_path)
+        error("Missing template: $template_path")
+    end
 
-Width=$(resolution[1])
-Height=$(resolution[2])
-
-Antialias=On
-Antialias_Depth=3
-Sampling_Method=2
-Antialias_Threshold=0.05
-
-;; # +W1920 +H1080
-+A0.1
-+AM2 +R3
-+Q09
-+UA
-
-; === Animation settings ===
-Initial_Frame=1
-Final_Frame=$nframes
-Initial_Clock=0
-Final_Clock=1
-Cyclic_Animation=Off
-Pause_when_Done=Off
-
-; === Performance tuning ===
-Bounding=Off
-Display=Off
-Verbose=Off
-"""
+    template = read(template_path, String)
+    ini_content = replace(
+        template,
+        "@INPUT_FILE@" => "mobius.pov",
+        "@WIDTH@" => string(resolution[1]),
+        "@HEIGHT@" => string(resolution[2]),
+        "@FINAL_FRAME@" => string(nframes),
+    )
     ini_path = joinpath(output_dir, "render.ini")
     write(ini_path, ini_content)
     # return ini_path


### PR DESCRIPTION
## Summary
- generate POV-Ray ini files by reading the shared assets/render.ini template
- add placeholders to the render.ini template for resolution and animation length

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: julia executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddac1b0cbc8327a2b43e852f3132a7