### PR TITLE
Relax input types for animation parameters

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,13 @@
 using MobiusSphereVisual
 using Test
+using LinearAlgebra
 
 @testset "MobiusSphereVisual.jl" begin
-    # Write your tests here.
+    @testset "input validation" begin
+        v, t, theta = MobiusSphereVisual.validate_inputs([0, 0, 2], 1, [1, 2, 3])
+        @test isapprox(norm(v), 1.0; atol=1e-12)
+        @test v ≈ [0.0, 0.0, 1.0]
+        @test t == [1.0, 2.0, 3.0]
+        @test theta === float(1)
+    end
 end


### PR DESCRIPTION
## Summary
- coerce rotation, translation, and angle inputs to floating-point vectors/scalars during validation
- update scene generation to work with the relaxed input types
- add a unit test covering integer vector inputs

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: `julia` executable not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddadc007a883278caa0272ed8b24eb