### PR TITLE
Improve temporary render preservation handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ render_mobius_animation(v, theta, t; nframes=120, quality=:medium)
 This command writes a temporary sequence of PNG frames with POV-Ray and stitches
 them together into `mobius.mp4` with ffmpeg. The finished video is moved to your
 current working directory while the intermediate frames are cleaned up. Pass
-`keep_temp=true` to retain a copy of the temporary render directory for
-debugging; if rendering fails, the directory is automatically copied to a
-`mobius_failure_…` folder so you can inspect the generated assets.
+`keep_temp=true` to retain a copy of the temporary render directory, including
+the finished video, for debugging; if rendering fails, the library copies the
+directory and any completed video into a `mobius_failure_…` folder so you can
+inspect the generated assets.
 
 ## Quality presets
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,9 +18,10 @@ Modules = [MobiusSphereVisual]
 `render_mobius_animation` exposes a `quality` keyword argument so you can match
 the rendering pipeline to your iteration speed. The function renders into a
 temporary directory that is cleaned up automatically; pass `keep_temp=true` to
-retain the intermediate POV-Ray frames for debugging. When rendering fails, the
-library copies the directory to a `mobius_failure_…` folder so you can inspect
-the generated POV-Ray inputs and partial frames:
+retain the intermediate POV-Ray frames—and the finished video—for debugging.
+When rendering fails, the library copies the directory and any completed video
+to a `mobius_failure_…` folder so you can inspect the generated POV-Ray inputs
+and partial frames:
 
 - `:draft` disables most antialiasing for extremely fast test renders and uses a
   veryfast ffmpeg preset.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,4 +55,24 @@ using Test
             rm(dest)
         end
     end
+
+    @testset "preserve_failure_assets" begin
+        mktempdir() do temp_dir
+            touch(joinpath(temp_dir, "frame0001.png"))
+
+            mktempdir() do final_dir
+                output = "mobius_test.mp4"
+                output_path = joinpath(final_dir, output)
+                touch(output_path)
+
+                failure_dir = MobiusSphereVisual.preserve_failure_assets(temp_dir, output, output_path)
+                @test isdir(failure_dir)
+                @test isfile(joinpath(failure_dir, "frame0001.png"))
+                @test isfile(joinpath(failure_dir, output))
+
+                rm(failure_dir; recursive=true)
+                rm(output_path)
+            end
+        end
+    end
 end


### PR DESCRIPTION
## Summary
- wrap `render_mobius_animation` in `mktempdir`, retain debugging directories on demand, and keep failure runs by copying the temp assets before cleanup
- ensure preserved directories include the finished video via new helpers that are covered by unit tests
- document the automatic failure retention and debugging option in the README and docs

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: julia executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de384ae37c83279cdb1274efcfe59a