### PR TITLE
Ensure render outputs use absolute paths

### DIFF
--- a/src/MobiusSphereVisual.jl
+++ b/src/MobiusSphereVisual.jl
@@ -180,6 +180,11 @@ function render_mobius_animation(
 )
     v = validate_inputs(v, theta, t)
 
+    output_path = abspath(output)
+    parent_dir = dirname(output_path)
+    if parent_dir != "."
+        mkpath(parent_dir)
+    end
 
     # mktempdir() do output_dir
     output_dir = mktempdir()
@@ -187,9 +192,9 @@ function render_mobius_animation(
     ini_file = generate_pov_ini(output_dir, nframes, resolution; quality=quality)
     povraycall(output_dir, v, theta, t, ini_file)
 
-    ffmpegcall(output_dir, output, fps, resolution, quality)
+    ffmpegcall(output_dir, output_path, fps, resolution, quality)
 
-    @info "Animation saved to: $output in $output_dir/$output"
+    @info "Animation saved to: $output_path"
     # Optionally keep temp dir for debugging by commenting out:
     # rm(output_dir, recursive=true)
 end


### PR DESCRIPTION
## Summary
- resolve the animation output path to an absolute location before rendering
- create the parent directory for custom output paths and forward the absolute path to ffmpeg
- log the final video location using the resolved absolute path

## Testing
- `julia --project -e 'using MobiusSphereVisual; render_mobius_animation([0.0,0.0,1.0], pi/3, [0.0,0.0,0.0]; output="examples/demo.mp4", nframes=5, quality=:draft)'` *(fails: julia not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de408545508327b257c0107a023894