### PR TITLE
Use mktempdir block for animation rendering

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,5 +2,8 @@ using MobiusSphereVisual
 using Test
 
 @testset "MobiusSphereVisual.jl" begin
-    # Write your tests here.
+    sample_mp4 = joinpath(tempdir(), "video.mp4")
+    sample_gif = joinpath(tempdir(), "gif_output.gif")
+    @test MobiusSphereVisual.derived_temp_destination(sample_mp4) == joinpath(dirname(sample_mp4), "video_frames")
+    @test MobiusSphereVisual.derived_temp_destination(sample_gif) == joinpath(dirname(sample_gif), "gif_output_frames")
 end


### PR DESCRIPTION
## Summary
- wrap render_mobius_animation's working directory in a mktempdir do-block so temporary files clean up automatically
- add an optional keep_temp keyword that copies the frames to a persistent directory and document the new behavior
- expose a helper for deriving the preserved frame directory and test its path construction logic

## Testing
- ⚠️ `julia --project -e 'using Pkg; Pkg.test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68de77ff2ca883278939e9f3f6c00179