### PR TITLE
Simplify quality presets and global settings helpers

### DIFF
--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,4 +1,81 @@
 # -- Miscelaneos helpers -----------------------------------------------------
+const QUALITY_PRESETS = Dict{Symbol, NamedTuple}(
+    :draft => (
+        pov = (
+            antialias = "Off",
+            antialias_depth = 1,
+            sampling_method = 1,
+            antialias_threshold = 0.3,
+            flags = "+A0.5\n+AM1 +R1\n+Q08\n+UA",
+            radiosity = false,
+            photons = false,
+        ),
+        ffmpeg = (
+            crf = 30,
+            preset = "veryfast",
+        ),
+    ),
+    :medium => (
+        pov = (
+            antialias = "On",
+            antialias_depth = 2,
+            sampling_method = 2,
+            antialias_threshold = 0.1,
+            flags = "+A0.2\n+AM2 +R3\n+Q09\n+UA",
+            radiosity = false,
+            photons = false,
+        ),
+        ffmpeg = (
+            crf = 23,
+            preset = "faster",
+        ),
+    ),
+    :high => (
+        pov = (
+            antialias = "On",
+            antialias_depth = 3,
+            sampling_method = 2,
+            antialias_threshold = 0.05,
+            flags = "+A0.1\n+AM2 +R3\n+Q09\n+UA",
+            radiosity = false,
+            photons = false,
+        ),
+        ffmpeg = (
+            crf = 20,
+            preset = "medium",
+        ),
+    ),
+    :ultra => (
+        pov = (
+            antialias = "On",
+            antialias_depth = 5,
+            sampling_method = 2,
+            antialias_threshold = 0.03,
+            flags = "+A0.03\n+AM2 +R5\n+Q11\n+UA",
+            radiosity = true,
+            photons = true,
+        ),
+        ffmpeg = (
+            crf = 18,
+            preset = "slow",
+        ),
+    ),
+    :film => (
+        pov = (
+            antialias = "On",
+            antialias_depth = 6,
+            sampling_method = 2,
+            antialias_threshold = 0.02,
+            flags = "+A0.02\n+AM2 +R7\n+Q13\n+UA",
+            radiosity = true,
+            photons = true,
+        ),
+        ffmpeg = (
+            crf = 16,
+            preset = "slower",
+        ),
+    ),
+)
 function derived_temp_destination(output_path::AbstractString)
     stem, _ = splitext(basename(output_path))
     return joinpath(dirname(output_path), "$(stem)_frames")
@@ -44,119 +121,48 @@ parameters so that a single keyword can trade fidelity for faster render
 times.
 """
 function quality_settings(quality::Symbol)
-    if quality == :draft
-        return (
-            pov = (
-                antialias = "Off",
-                antialias_depth = 1,
-                sampling_method = 1,
-                antialias_threshold = 0.3,
-                flags = "+A0.5\n+AM1 +R1\n+Q08\n+UA",
-                radiosity = false,
-                photons = false,
-            ),
-            ffmpeg = (
-                crf = 30,
-                preset = "veryfast",
-            ),
-        )
-    elseif quality == :medium
-        return (
-            pov = (
-                antialias = "On",
-                antialias_depth = 2,
-                sampling_method = 2,
-                antialias_threshold = 0.1,
-                flags = "+A0.2\n+AM2 +R3\n+Q09\n+UA",
-                radiosity = false,
-                photons = false,
-            ),
-            ffmpeg = (
-                crf = 23,
-                preset = "faster",
-            ),
-        )
-    elseif quality == :high
-        return (
-            pov = (
-                antialias = "On",
-                antialias_depth = 3,
-                sampling_method = 2,
-                antialias_threshold = 0.05,
-                flags = "+A0.1\n+AM2 +R3\n+Q09\n+UA",
-                radiosity = false,
-                photons = false,
-            ),
-            ffmpeg = (
-                crf = 20,
-                preset = "medium",
-            ),
-        )
-    elseif quality == :ultra
-        return (
-            pov = (
-                antialias = "On",
-                antialias_depth = 5,
-                sampling_method = 2,
-                antialias_threshold = 0.03,
-                flags = "+A0.03\n+AM2 +R5\n+Q11\n+UA",
-                radiosity = true,
-                photons = true,
-            ),
-            ffmpeg = (
-                crf = 18,
-                preset = "slow",
-            ),
-        )
-    elseif quality == :film
-        return (
-            pov = (
-                antialias = "On",
-                antialias_depth = 6,
-                sampling_method = 2,
-                antialias_threshold = 0.02,
-                flags = "+A0.02\n+AM2 +R7\n+Q13\n+UA",
-                radiosity = true,
-                photons = true,
-            ),
-            ffmpeg = (
-                crf = 16,
-                preset = "slower",
-            ),
-        )
-    else
-        valid = join(string.((:draft, :medium, :high, :ultra, :film)), ", ")
+    if !haskey(QUALITY_PRESETS, quality)
+        valid = join(string.(collect(keys(QUALITY_PRESETS))), ", ")
         throw(ArgumentError("Unknown quality preset: $quality. Supported presets: $valid"))
     end
+    return QUALITY_PRESETS[quality]
 end
 
+const RADIOSITY_BLOCK = join(
+    [
+        "  radiosity {",
+        "    pretrace_start 0.08",
+        "    pretrace_end 0.005",
+        "    count 200",
+        "    recursion_limit 2",
+        "    nearest_count 10",
+        "    low_error_factor 0.5",
+        "    minimum_reuse 0.015",
+        "    maximum_reuse 0.1",
+        "    brightness 1.0",
+        "  }",
+    ],
+    "\n",
+)
+
+const PHOTONS_BLOCK = join(
+    [
+        "  photons {",
+        "    spacing 0.025",
+        "    gather 40, 80",
+        "    max_trace_level 12",
+        "  }",
+    ],
+    "\n",
+)
+
 function global_settings_extra(pov_settings::NamedTuple)
-    buffer = IOBuffer()
+    sections = String[]
     if get(pov_settings, :radiosity, false)
-        print(
-            buffer,
-            "\n  radiosity {\n",
-            "    pretrace_start 0.08\n",
-            "    pretrace_end 0.005\n",
-            "    count 200\n",
-            "    recursion_limit 2\n",
-            "    nearest_count 10\n",
-            "    low_error_factor 0.5\n",
-            "    minimum_reuse 0.015\n",
-            "    maximum_reuse 0.1\n",
-            "    brightness 1.0\n",
-            "  }",
-        )
+        push!(sections, RADIOSITY_BLOCK)
     end
     if get(pov_settings, :photons, false)
-        print(
-            buffer,
-            "\n  photons {\n",
-            "    spacing 0.025\n",
-            "    gather 40, 80\n",
-            "    max_trace_level 12\n",
-            "  }",
-        )
+        push!(sections, PHOTONS_BLOCK)
     end
-    return String(take!(buffer))
+    return isempty(sections) ? "" : "\n" * join(sections, "\n")
 end


### PR DESCRIPTION
## Summary
- replace the OrderedCollections dependency by using Julia's built-in `Dict` for quality presets
- refactor `global_settings_extra` to compose reusable radiosity and photon blocks without manual buffering

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: `julia` binary not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e105d08e1483279083626e1030fe95