### PR TITLE
Update docs to reflect tuple-based parameter usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ using MobiusSphere
 using MobiusSphereVisual
 
 mobius = MobiusSphere.example_loxodromic()  # replace with your own construction
-coeffs = MobiusSphere.motion_parameters(mobius)  # returns axis/angle/translation data
+coeffs = MobiusSphere.motion_parameters(mobius)  # returns (v, theta, t)
 
-render_mobius_animation(coeffs; output="examples/loxodromic.mp4", nframes=120)
+render_mobius_animation(coeffs...; output="examples/loxodromic.mp4", nframes=120)
 ```
 
 ## Quality presets
@@ -62,14 +62,14 @@ Similarly, the ffmpeg presets balance compression quality and encoding speed—t
 faster settings write files quickly at the cost of larger sizes and slightly
 lower detail.
 
-When you need the raw pieces, the new [`coerce_motion_parameters`](https://LauraBMo.github.io/MobiusSphereVisual.jl/dev/reference/#MobiusSphereVisual.coerce_motion_parameters) utility converts any compatible coefficient object into `(v, theta, t)` tuples:
+When you need the raw pieces, unpack the tuple manually and pass the components to `render_mobius_animation`:
 
 ```julia
 using MobiusSphereVisual
 
-coeffs = (axis = [0.0, 0.0, 1.0], angle = pi / 2, translation = [0.2, 0.0, 0.0])
+params = ([0.0, 0.0, 1.0], pi / 2, [0.2, 0.0, 0.0])
 
-v, theta, t = coerce_motion_parameters(coeffs)
+v, theta, t = params
 render_mobius_animation(v, theta, t; output="examples/from_tuple.mp4", nframes=120)
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -20,14 +20,15 @@ render_mobius_animation(v, theta, t; output="examples/demo.mp4", nframes=120)
 
 ## Using coefficients from MobiusSphere.jl
 
-`MobiusSphere.jl` returns coefficient objects that carry the axis, rotation angle and translation used by the Möbius motion. The renderer accepts those objects directly, or you can turn them into raw tuples via [`coerce_motion_parameters`](@ref):
+`MobiusSphere.jl` returns coefficient objects that carry the axis, rotation angle and translation used by the Möbius motion. Destructure the triple into `(v, theta, t)` before calling the renderer so the arguments match the current method signature:
 
 ```julia
 using MobiusSphereVisual
 
-coeffs = (axis = [0.0, 0.0, 1.0], angle = pi / 2, translation = [0.2, 0.0, 0.0])
+coeffs = ([0.0, 0.0, 1.0], pi / 2, [0.2, 0.0, 0.0])
 
-render_mobius_animation(coeffs; output="examples/from_coeffs.mp4", nframes=120)
+v, theta, t = coeffs
+render_mobius_animation(v, theta, t; output="examples/from_coeffs.mp4", nframes=120)
 ```
 
 ```@autodocs


### PR DESCRIPTION
## Summary
- update the README examples to use tuple splatting so they match `render_mobius_animation`
- describe manual tuple destructuring in the docs instead of the removed `coerce_motion_parameters` utility

## Testing
- `julia --project=docs docs/make.jl` *(fails: `command not found: julia` in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1114c0b708327b3edc7e59506dfc7