### PR TITLE
Add documentation for utility helper functions

### DIFF
--- a/src/FFmpegCall.jl
+++ b/src/FFmpegCall.jl
@@ -1,8 +1,12 @@
-# ffmpegcall.jl
-# not using FFMPEG
-# using local ffmpeg
+"""
+    detect_frame_pattern(output_dir; rx=r"frame_(\d+)\.png")
 
-## POV-Ray not allow predefine output string, which is needed by ffmepg, funny enough.
+Scan `output_dir` for image frames and derive the printf-style pattern used by
+FFmpeg. The default regular expression matches files named like
+`frame_0001.png` and extracts the zero-padded index to determine the required
+padding width. Returns a string such as `"frame_%04d.png"`. Throws an
+`ArgumentError` if no matching files are found.
+"""
 function detect_frame_pattern(output_dir::String, rx = r"frame_(\d+)\.png")
     for file in readdir(output_dir)
         m = match(rx, file)
@@ -12,7 +16,7 @@ function detect_frame_pattern(output_dir::String, rx = r"frame_(\d+)\.png")
             return "frame_%0$(ndigits)d.png"
         end
     end
-    error("No frame_*.png files found in $output_dir")
+    throw(ArgumentError("No frame_*.png files found in $output_dir"))
 end
 
 """

--- a/src/Files.jl
+++ b/src/Files.jl
@@ -76,6 +76,14 @@ function generate_pov_ini(
     return "render.ini"
 end
 
+"""
+    generate_pov(v, theta, t, output_dir, nframes, resolution; quality=:high, sampling=nothing)
+
+Create the POV-Ray scene and configuration files for an animation render.
+Returns a tuple containing the `.ini` filename and the path to the generated
+scene. Quality presets are merged with optional `sampling` overrides before
+delegating to `generate_pov_ini` and `generate_pov_scene`.
+"""
 function generate_pov(
     v::Vector{Float64},
     theta::Float64,
@@ -86,19 +94,23 @@ function generate_pov(
     quality::Symbol=:high,
     sampling::Union{Nothing,NamedTuple,Dict}=nothing,
     )
-    ## Processing kwargs
     sampling = _normalize_sampling_overrides(sampling)
     settings = merge(quality_settings(quality).pov, sampling)
     global_settings = global_settings_extra(settings)
 
-    ## Create the actual files
     ini_file = generate_pov_ini(output_dir, nframes, resolution; settings=settings)
     scene = generate_pov_scene(v, theta, t, output_dir;
                                global_settings_extra = global_settings)
-    ## Return name, path
     return ini_file, scene
 end
 
+"""
+    _normalize_sampling_overrides(sampling)
+
+Normalize sampling overrides into a `NamedTuple`. Accepts `nothing`, an
+existing `NamedTuple`, or a `Dict` whose keys are converted to symbols. Throws
+an `ArgumentError` for any other input type.
+"""
 function _normalize_sampling_overrides(sampling)
     if sampling === nothing
         return NamedTuple()

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -1,9 +1,23 @@
-# -- Miscelaneos helpers -----------------------------------------------------
+# -- Miscellaneous helpers ----------------------------------------------------
+"""
+    derived_temp_destination(output_path)
+
+Return the directory path used to store intermediate frames for a render.
+The directory is derived from `output_path` by appending a `_frames` suffix to
+the output file name and reusing the same parent directory.
+"""
 function derived_temp_destination(output_path::AbstractString)
     stem, _ = splitext(basename(output_path))
     return joinpath(dirname(output_path), "$(stem)_frames")
 end
 
+"""
+    povraycall(output_dir, ini_file)
+
+Invoke POV-Ray to render frames described by `ini_file` inside `output_dir`.
+The function logs the working directory for transparency and forwards the
+`.ini` file to the `povray` executable using Julia's `run`.
+"""
 function povraycall(output_dir, ini_file)
     @info "Working in temporary directory: $output_dir"
     @info "Rendering frames with POV-Ray..."
@@ -11,6 +25,13 @@ function povraycall(output_dir, ini_file)
 end
 
 # -- Validation helpers -----------------------------------------------------
+"""
+    _validate_resolution(resolution)
+
+Ensure that the `(width, height)` tuple contains positive integers, returning
+the tuple unchanged. Throws an `ArgumentError` when either dimension is zero
+or negative.
+"""
 function _validate_resolution(resolution::Tuple{Int,Int})
     width, height = resolution
     if width <= 0 || height <= 0


### PR DESCRIPTION
## Summary
- add docstrings for the helper functions in `Utils.jl`
- document frame pattern detection and return a clearer error when frames are missing
- document POV-Ray file generation helpers to clarify their contracts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e10e3fcfe48327a5f1a53ccceffae6