### PR TITLE
Inline example animations in scripts

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,6 +18,14 @@ t = [0.2, 0.0, 0.0]
 render_mobius_animation(v, theta, t; output="examples/demo.mp4", nframes=120)
 ```
 
+## Examples
+
+Browse `examples/example.jl` for ready-to-run scripts that render classic
+Möbius motions such as a 90° rotation or a loxodromic spiral. Each block
+shows the arguments passed directly into [`render_mobius_animation`](@ref)
+so you can tweak the vectors, angle, or keyword parameters to suit your
+own scene.
+
 ## Using coefficients from MobiusSphere.jl
 
 `MobiusSphere.jl` returns coefficient objects that carry the axis, rotation angle and translation used by the Möbius motion. Destructure the triple into `(v, theta, t)` before calling the renderer so the arguments match the current method signature:

--- a/examples/example.jl
+++ b/examples/example.jl
@@ -3,11 +3,35 @@ using MobiusSphereVisual
 
 # Example 1: Simple rotation
 println("Creating rotation animation...")
-MobiusSphereVisual.example_rotation_animation()
+rotation_axis = [0.0, 0.0, 1.0]
+rotation_angle = π / 2
+rotation_translation = [0.0, 0.0, 0.0]
+MobiusSphereVisual.render_mobius_animation(
+    rotation_axis,
+    rotation_angle,
+    rotation_translation;
+    output="rotation.mp4",
+    fps=30,
+    resolution=(1280, 720),
+    nframes=120,
+    quality=:high,
+)
 
 # Example 2: Loxodromic transformation
 println("Creating loxodromic animation...")
-MobiusSphereVisual.example_loxodromic_animation()
+loxodromic_axis = [0.0, 0.0, 1.0]
+loxodromic_angle = π / 3
+loxodromic_translation = [0.25, 0.0, 0.15]
+MobiusSphereVisual.render_mobius_animation(
+    loxodromic_axis,
+    loxodromic_angle,
+    loxodromic_translation;
+    output="loxodromic.mp4",
+    fps=30,
+    resolution=(1280, 720),
+    nframes=150,
+    quality=:high,
+)
 
 # Example 3: Custom transformation
 println("Creating custom transformation...")


### PR DESCRIPTION
## Summary
- remove the exported example helper wrappers from `MobiusSphereVisual`
- inline the rotation and loxodromic demos inside `examples/example.jl`
- update the documentation to point readers at the example script for ready-to-run transforms

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: `julia` executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e12521c86c832782bcad5d754c5ac4