### PR TITLE
First-pass Arnold aesthetic: fix hue wheel, glass, lighting, floor

### DIFF
--- a/assets/mobius_macros.inc
+++ b/assets/mobius_macros.inc
@@ -1,47 +1,62 @@
-// ===============================================
-// Macros for Möbius Sphere Scene
-// ===============================================
+// ===================================================
+// Macros for Mobius Sphere Scene  (ASCII-only)
+// ===================================================
 
-// Function definitions for latitude and longitude
-#declare Fn_long = function(x,y,z) { atan2(z,x) }
-#declare Fn_lat  = function(x,y,z) { acos(y/sqrt(x*x+y*y+z*z)) }
+// Longitude: raw atan2 in [-pi, pi], and normalized to [0, 2*pi).
+#declare Fn_long     = function(x,y,z) { atan2(z,x) }
+#declare Fn_long_01  = function(x,y,z) { mod(atan2(z,x) + 2*pi, 2*pi) }
+// Latitude: acos gives [0, pi]; 0 at north pole, pi at south pole.
+#declare Fn_lat      = function(x,y,z) { acos(y/sqrt(x*x+y*y+z*z)) }
 
-// Rainbow pigment (argument coloring) macro
+// --------------------------------------------------
+// Rainbow pigment: argument (longitude) as hue wheel
+// --------------------------------------------------
+// Formula normalizes atan2 in [-pi,pi] to [0,1] with red at angle=0
+// (positive x-axis), matching the standard argument-coloring convention.
+// Pure rgb with no filter keeps the colours saturated and opaque.
 #macro RainbowPigment()
   pigment {
-    function { atan2(z,x) } // longitude angle
+    function { mod(atan2(z,x) + 2*pi, 2*pi) / (2*pi) }
     color_map {
-      // rgbf entries keep ~30% filter so transmitted light inherits the tint,
-      // letting the argument cap cast the prismatic shadow seen in the film.
-      [0.0 rgbf <1,0,0,0.3>]
-      [0.16 rgbf <1,1,0,0.3>]
-      [0.33 rgbf <0,1,0,0.3>]
-      [0.50 rgbf <0,1,1,0.3>]
-      [0.66 rgbf <0,0,1,0.3>]
-      [0.83 rgbf <1,0,1,0.3>]
-      [1.0 rgbf <1,0,0,0.3>]
+      [0.00 rgb <1,0,0>]
+      [0.16 rgb <1,1,0>]
+      [0.33 rgb <0,1,0>]
+      [0.50 rgb <0,1,1>]
+      [0.66 rgb <0,0,1>]
+      [0.83 rgb <1,0,1>]
+      [1.00 rgb <1,0,0>]
     }
   }
 #end
 
-// Spherical lat/long grid pigment
+// --------------------------------------------------
+// Grid pigment: symmetric distance for uniform lines
+// --------------------------------------------------
+// Using min(mod, spacing - mod) gives equal-width lines on both sides
+// of each grid angle instead of the one-sided artifact from mod alone.
+// delta_lat / delta_lon in radians; eps controls line half-width.
 #macro GridPigment(delta_lat, delta_lon, eps)
   pigment {
     function {
-      (abs(mod(Fn_lat(x,y,z), delta_lat)) < eps) |
-      (abs(mod(Fn_long(x,y,z), delta_lon)) < eps)
+      (min(mod(Fn_lat(x,y,z), delta_lat),
+           delta_lat - mod(Fn_lat(x,y,z), delta_lat)) < eps) |
+      (min(mod(Fn_long_01(x,y,z), delta_lon),
+           delta_lon - mod(Fn_long_01(x,y,z), delta_lon)) < eps)
     }
     color_map {
-      [0 rgbt <0,0,0,1>]
-      [0.5 rgb <0,0,0>]
-      [1 rgb <0,0,0>]
+      [0.0 rgbt <0,0,0,1>]
+      [0.5 rgb  <0,0,0>]
+      [1.0 rgb  <0,0,0>]
     }
   }
 #end
 
-// Glass shell inspired by the luminous sphere in "Möbius Transformations Revealed":
-// - Fresnel reflection keeps the rim highlights bright while preserving transparency.
-// - IOR 1.52 approximates the dense glass used in the film's reference model.
+// --------------------------------------------------
+// Glass shell: the outer transparent sphere
+// --------------------------------------------------
+// Strong Fresnel range (0.03 -> 0.95) keeps the rim bright while
+// leaving the face mostly transparent so the coloured cap shows through.
+// Tight roughness 0.001 gives the sharp specular spot in the Arnold film.
 #macro SphereGlassShell()
   sphere { <0,0,0>, 1
     texture {
@@ -49,59 +64,60 @@
       finish {
         ambient 0
         diffuse 0
-        specular 0.85
-        roughness 0.002
-        reflection { 0.02, 0.25 fresnel on }
+        specular 1.0
+        roughness 0.001
+        reflection { 0.03, 0.95 fresnel on }
         conserve_energy
       }
     }
     interior {
       ior 1.52
-      // Long fade settings mimic the subtle absorption in the cinematography plates.
-      fade_power 1001
-      fade_distance 5
+      fade_color rgb <0.92, 0.93, 1.0>
+      fade_distance 3
+      fade_power 2
     }
     hollow on
   }
 #end
 
-// Argument-colored cap matches the saturated stereographic disk from the film:
-// - Rainbow pigment reproduces the argument ramp.
-// - Grid overlay echoes the lat/long guide used to explain mappings.
+// --------------------------------------------------
+// Argument-coloured lower hemisphere
+// --------------------------------------------------
+// Clipped at y<=0 (equator) to expose the saturated hue wheel on the
+// south half while leaving the north half as clear glass.
+// Grid layer overlaid on top via a second texture.
 #macro SphereArgumentCap(delta_lat, delta_lon, eps)
   sphere { <0,0,0>, 1
     texture {
       RainbowPigment()
       finish {
-        ambient 0
-        diffuse 0.12
-        specular 0.45
-        roughness 0.005
-        reflection 0.05
+        ambient 0.02
+        diffuse 0.85
+        specular 0.35
+        roughness 0.008
+        reflection 0.04
         conserve_energy
       }
     }
     texture {
       GridPigment(delta_lat, delta_lon, eps)
       finish {
-        ambient 0.1
-        diffuse 0.25
-        specular 0.1
-        roughness 0.015
+        ambient 0
+        diffuse 0.5
+        specular 0.05
+        roughness 0.05
       }
     }
-    interior {
-      ior 1.36
-      fade_color rgb <0.8, 0.9, 1.2>
-      fade_distance 6
-      fade_power 2
-    }
     hollow on
-    clipped_by { plane { y, 0.8 } }  // Clipped at y = 0.8 as requested
+    clipped_by { plane { y, 0 } }
   }
 #end
 
-// Thin sheen layer adds the soft bloom present in the cinematography plates.
+// --------------------------------------------------
+// Specular sheen over the coloured cap
+// --------------------------------------------------
+// A transparent layer with tight specular makes the lower hemisphere
+// look glassy without hiding the rainbow colours underneath.
 #macro SphereHighlightSheen()
   sphere { <0,0,0>, 1
     texture {
@@ -109,20 +125,19 @@
       finish {
         ambient 0
         diffuse 0
-        specular 0.4
-        roughness 0.015
-        metallic 0.1
+        specular 0.6
+        roughness 0.008
       }
     }
     clipped_by { plane { y, 0 } }
   }
 #end
 
-// Complete sphere with glass shell, argument cap and highlight sheen
+// Convenience macro: full sphere assembly used in the template.
 #macro SphereGrid()
   union {
     SphereGlassShell()
-    SphereArgumentCap(pi/8, pi/8, 0.02)
+    SphereArgumentCap(pi/8, pi/8, 0.015)
     SphereHighlightSheen()
   }
 #end

--- a/assets/mobius_scene.inc
+++ b/assets/mobius_scene.inc
@@ -1,35 +1,55 @@
-// ===============================================
-// Scene Configuration for Möbius Sphere
-// ===============================================
+// ===================================================
+// Scene Configuration for Mobius Sphere  (ASCII-only)
+// ===================================================
 
-// Camera setup
-#declare MobiusCamera = 
+// --------------------------------------------------
+// Camera
+// --------------------------------------------------
+// Positioned so the look-direction drops ~18 degrees below horizontal,
+// giving a slight top-down view with headroom above the sphere.
+// angle 38 widens the FOV just enough to frame the floor reflection.
+#declare MobiusCamera =
   camera {
     location <0, 3, -8>
-    look_at <0, 1, 0>
-    angle 35
+    look_at  <0, 0.2, 0>
+    angle 38
   }
 
-// Background color
-#declare BackgroundColor = color rgb <0.02, 0.02, 0.08>
+// --------------------------------------------------
+// Background
+// --------------------------------------------------
+// Near-black with a faint blue tint matches the dark void in the film.
+#declare BackgroundColor = color rgb <0.005, 0.005, 0.01>
 
-// Light source at the north pole of the Möbius ball
-#declare NorthPoleLight = 
-  light_source { 
-    <0, 1.001, 0>, 
-    rgb <2.1, 2.1, 1.4> * 0.55 
+// --------------------------------------------------
+// Key light (north-pole tracker -- base position)
+// --------------------------------------------------
+// Declared here for reference; the template recomputes the animated
+// position each frame by applying CurrentTransform.
+#declare NorthPoleLightBase = <0, 2.5, 0>
+#declare NorthPoleLightColor = rgb <1.5, 1.4, 1.2>
+
+// Convenience object used when no animation transform is needed.
+#declare NorthPoleLight =
+  light_source {
+    NorthPoleLightBase,
+    NorthPoleLightColor
   }
 
-// Light source position marker
-#declare LightMarker = 
-  sphere {
-    <0, 1.001, 0>, 0.02
-    texture { pigment { color rgb <1,0.9,0.6> } finish { emission 1 } }
-    no_shadow
+// --------------------------------------------------
+// Fill light (static -- does not follow the sphere)
+// --------------------------------------------------
+// Cool, dim fill from the front-left below horizon reduces pure-black
+// shadow regions without washing out the dark background.
+#declare FillLight =
+  light_source {
+    <-4, -0.5, -5>, rgb <0.08, 0.08, 0.16>
   }
 
-// Floor plane with checker texture
-#declare FloorPlane = 
+// --------------------------------------------------
+// Floor plane
+// --------------------------------------------------
+#declare FloorPlane =
   plane {
     y, -1
     texture { GrayCheckerFloor }

--- a/assets/mobius_template.pov
+++ b/assets/mobius_template.pov
@@ -4,7 +4,7 @@
 #include "glass.inc"
 #include "transforms.inc"
 
-// Local files
+// Local scene files
 #include "mobius_macros.inc"
 #include "mobius_textures.inc"
 #include "mobius_scene.inc"
@@ -13,40 +13,20 @@ global_settings {
   assumed_gamma 1.0@GLOBAL_SETTINGS_EXTRA@
 }
 
-// Use the configured camera
 camera { MobiusCamera }
 
-// Use the configured background
 background { BackgroundColor }
 
-// Use the configured floor
 object { FloorPlane }
 
-// plane { y, 0
-  //   pigment{
-    //     checker White Black
-    //     scale 0.5
-    //   }
-  // }
+// Static fill light (does not follow the sphere)
+object { FillLight }
 
-// #declare RainbowPolar = pigment {
-  //   uv_mapping
-  //   gradient u
-  //   color_map {
-    //     [0.00 rgb <1,0,0>]
-    //     [0.16 rgb <1,1,0>]
-    //     [0.33 rgb <0,1,0>]
-    //     [0.50 rgb <0,1,1>]
-    //     [0.66 rgb <0,0,1>]
-    //     [0.83 rgb <1,0,1>]
-    //     [1.00 rgb <1,0,0>]
-    //   }
-  //   quick_color rgb <1,0.5,0>
-  // }
-
-
-
-// Compute current transform based on clock
+// --------------------------------------------------
+// Animation transform based on clock in [0, 1]
+// --------------------------------------------------
+// First half [0, 0.5]: rotate around axis v by angle theta
+// Second half [0.5, 1]: hold rotation, translate by t
 #if (clock <= 0.5)
   #declare CurrentTransform = transform {
     #local rot_ang = clock * 2 * @THETA@;
@@ -59,35 +39,27 @@ object { FloorPlane }
   };
 #end
 
-// Compute current north pole for light
-#declare BaseNorthPole = <0, 1.001, 0>;
+// --------------------------------------------------
+// Key light: tracks the sphere's north pole
+// --------------------------------------------------
+// Base position is 1.5 units above sphere surface so the light
+// spreads across the whole sphere rather than from a point on skin.
+#declare BaseNorthPole = <0, 2.5, 0>;
 #declare CurrentNorthPole = vtransform(BaseNorthPole, CurrentTransform);
 
-// Emissive light at current north pole (using updated position)
-light_source { CurrentNorthPole, rgb <2.1, 2.1, 1.4> * 0.55 }
+light_source { CurrentNorthPole, rgb <1.5, 1.4, 1.2> }
 
-// small visible marker for the light source
-sphere {
-  CurrentNorthPole, 0.02
-  texture { pigment { color rgb <1,0.9,0.6> } finish { emission 1 } }
-  no_shadow
-}
-
-// The Möbius ball - a blurry unit ball with rainbow-colored gird covering the bottom half up to 0.8 in height
+// --------------------------------------------------
+// Sphere assembly
+// --------------------------------------------------
 #declare MoebiusBall =
   union {
-    // Glass shell for the blurry effect
     SphereGlassShell()
-    
-    // Rainbow-colored gird covering the bottom half up to 0.8 in height
-    SphereArgumentCap(pi/8, pi/8, 0.02)
-    
-    // Highlight sheen
+    SphereArgumentCap(pi/8, pi/8, 0.015)
     SphereHighlightSheen()
   };
 
 object {
   MoebiusBall
-  // Apply common transform: first move to admissible position, then animate
   transform { CurrentTransform }
 }

--- a/assets/mobius_textures.inc
+++ b/assets/mobius_textures.inc
@@ -1,33 +1,26 @@
-// ===============================================
-// Textures for Möbius Sphere Scene
-// ===============================================
+// ===================================================
+// Textures for Mobius Sphere Scene  (ASCII-only)
+// ===================================================
 
-// Gray checker floor texture
-#declare GrayCheckerFloor = 
+// --------------------------------------------------
+// Floor: dark checker, barely visible
+// --------------------------------------------------
+// Very low-contrast pair of near-blacks so the floor does not
+// compete with the sphere for attention, while a gentle Fresnel
+// reflection lets the sphere cast a soft mirror image below.
+#declare GrayCheckerFloor =
   texture {
     pigment {
       checker
-      color rgbf <0.8, 0.8, 0.8, 0.5>
-      color rgbf <0.6, 0.6, 0.6, 0.5>
-      scale 0.4
+      color rgb <0.04, 0.04, 0.05>
+      color rgb <0.08, 0.08, 0.10>
+      scale 0.55
     }
     finish {
-      ambient 0.3
-      diffuse 0.7
-      reflection 0.1
+      ambient 0
+      diffuse 0.6
+      reflection { 0.12, 0.18 fresnel on }
+      specular 0.05
+      roughness 0.3
     }
   }
-
-// Rainbow pigment (argument coloring) for the Möbius ball
-#declare RainbowPolar = pigment {
-  onion
-  warp { spherical }
-  color_map {
-    [0.00 color rgbf <0.3,0.3,1,0.5>]   // indigo
-    [0.30 color rgbf <0.0,1,0.5,0.5>]   // green
-    [0.60 color rgbf <1,0.7,0.0,0.5>]   // orange
-    [0.90 color rgbf <0.6,0.0,1,0.5>]   // violet
-    [1.00 color rgbf <0.3,0.3,1,0.5>]   // wrap back to indigo
-  }
-  scale 0.25
-}

--- a/src/Files.jl
+++ b/src/Files.jl
@@ -132,15 +132,13 @@ end
     copy_macros(output_dir)
 """
 function copy_macros(output_dir::String)
-    _file = "macros.inc"
-    _path = joinpath(ASSETS_DIR, _file)
-    if !isfile(_path)
-        error("Missing file: $_path")
+    files = ["mobius_macros.inc", "mobius_textures.inc", "mobius_scene.inc"]
+    for _file in files
+        _path = joinpath(ASSETS_DIR, _file)
+        if !isfile(_path)
+            error("Missing asset file: $_path")
+        end
+        cp(_path, joinpath(output_dir, _file))
+        @debug "Copied $(_file) to: $output_dir"
     end
-
-    dest_path = joinpath(output_dir, _file)
-    # Copy the shared macros file into the temporary render directory.
-    cp(_path, dest_path)
-    @debug "Copied macros file to: $dest_path"
-    return _file
 end


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

This PR implements the first round of texture/lighting changes to move the render toward the Arnold & Rogness *"Möbius Transformations Revealed"* aesthetic. It also fixes a critical pipeline bug where the wrong `.inc` files were being staged for the renderer.

### Bug fixes

- **`src/Files.jl` — `copy_macros`**: was copying `macros.inc` (which the template never includes) instead of the three files the template actually needs: `mobius_macros.inc`, `mobius_textures.inc`, `mobius_scene.inc`. Without this fix the render fails at the POV-Ray `#include` stage.

### Aesthetic changes

**`assets/mobius_macros.inc`**
- `RainbowPigment`: the old `function { atan2(z,x) }` returned raw values in `[-π, π]`, producing garbage colour indices. Fixed to `mod(atan2(z,x) + 2*pi, 2*pi) / (2*pi)` → `[0,1]` with red at angle = 0 (positive x-axis), matching the standard argument-colouring convention.
- `GridPigment`: replaced `abs(mod(f, spacing)) < eps` (one-sided, half-width lines) with `min(mod(f, spacing), spacing - mod(f, spacing)) < eps` for symmetric, equal-width lines. Longitude now uses the normalized `[0, 2π)` angle so negative-atan2 values don't produce gaps.
- `SphereArgumentCap`: clip plane was `y, 0.8` (colouring 80 % of the sphere). Fixed to `y, 0` (lower hemisphere only). Removed interior/IOR block; colours are now fully opaque `rgb` for maximum saturation.
- `SphereGlassShell`: Fresnel range `0.02→0.25` → `0.03→0.95` for bright rim highlights; specular `1.0`, roughness `0.001` for the sharp specular spot visible in the film.
- `SphereHighlightSheen`: tighter roughness `0.008`, higher specular `0.6` for a glossy cap.

**`assets/mobius_scene.inc`**
- Background darkened from navy `(0.02, 0.02, 0.08)` to near-black `(0.005, 0.005, 0.010)`.
- Camera `look_at` moved to `<0, 0.2, 0>` and FOV widened to `38°` — gives ~18° downward angle with headroom above the sphere.
- `FillLight` declared: dim cool `rgb(0.08, 0.08, 0.16)` from front-left to lift pure-black shadows.

**`assets/mobius_textures.inc`**
- Checker floor darkened from `0.6/0.8` gray to `0.04/0.08` near-black pair with Fresnel reflection `0.12→0.18` for a faint mirror image of the sphere.

**`assets/mobius_template.pov`**
- `BaseNorthPole` moved from `<0, 1.001, 0>` (on the sphere skin, causing self-shadowing) to `<0, 2.5, 0>` (1.5 units above surface for broad even coverage).
- Key light colour changed to warm white `rgb(1.5, 1.4, 1.2)`.
- Removed the emissive `LightMarker` sphere that appeared in every frame.
- `FillLight` emitted as a static scene object.

## Test plan

- [ ] Pull branch; run `render_mobius_animation([0.,0.,1.], π/4, [0.,0.,0.]; quality=:draft, nframes=4)`
- [ ] Verify all four frames render without POV-Ray parse errors
- [ ] Inspect frame: lower hemisphere shows saturated red→yellow→green→cyan→blue→magenta ring; upper hemisphere is clear glass; equator is a clean black grid line
- [ ] Background is near-black, floor barely visible with faint checker
- [ ] Bright specular spot on upper-left rim of sphere (Fresnel highlight)
- [ ] Repeat at `quality=:high` for final check

https://claude.ai/code/session_016mKYf4sYcP3wN9LjbYoNhN
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_016mKYf4sYcP3wN9LjbYoNhN)_