### PR TITLE
Round 1: opaque rainbow cap, crystal-orb glass, fix copy/clip bugs

### DIFF
--- a/assets/mobius_macros.inc
+++ b/assets/mobius_macros.inc
@@ -1,25 +1,25 @@
 // ===============================================
-// Macros for Möbius Sphere Scene
+// Macros for Mobius Sphere Scene
 // ===============================================
 
 // Function definitions for latitude and longitude
 #declare Fn_long = function(x,y,z) { atan2(z,x) }
 #declare Fn_lat  = function(x,y,z) { acos(y/sqrt(x*x+y*y+z*z)) }
 
-// Rainbow pigment (argument coloring) macro
+// Rainbow pigment (argument coloring). Opaque saturated hues so the cap reads
+// like the painted lower hemisphere from "Mobius Transformations Revealed":
+// red -> yellow -> green -> cyan -> blue -> magenta -> red around the equator.
 #macro RainbowPigment()
   pigment {
-    function { atan2(z,x) } // longitude angle
+    function { (atan2(z,x) + pi) / (2*pi) }
     color_map {
-      // rgbf entries keep ~30% filter so transmitted light inherits the tint,
-      // letting the argument cap cast the prismatic shadow seen in the film.
-      [0.0 rgbf <1,0,0,0.3>]
-      [0.16 rgbf <1,1,0,0.3>]
-      [0.33 rgbf <0,1,0,0.3>]
-      [0.50 rgbf <0,1,1,0.3>]
-      [0.66 rgbf <0,0,1,0.3>]
-      [0.83 rgbf <1,0,1,0.3>]
-      [1.0 rgbf <1,0,0,0.3>]
+      [0.000 rgb <1.00, 0.05, 0.05>]
+      [0.167 rgb <1.00, 0.95, 0.05>]
+      [0.333 rgb <0.05, 0.85, 0.20>]
+      [0.500 rgb <0.05, 0.85, 0.95>]
+      [0.667 rgb <0.10, 0.20, 1.00>]
+      [0.833 rgb <0.95, 0.10, 0.85>]
+      [1.000 rgb <1.00, 0.05, 0.05>]
     }
   }
 #end
@@ -39,9 +39,8 @@
   }
 #end
 
-// Glass shell inspired by the luminous sphere in "Möbius Transformations Revealed":
-// - Fresnel reflection keeps the rim highlights bright while preserving transparency.
-// - IOR 1.52 approximates the dense glass used in the film's reference model.
+// Glass shell inspired by the luminous sphere in "Mobius Transformations Revealed":
+// crystal-orb feel with bright Fresnel rim and a small internal-glow tint.
 #macro SphereGlassShell()
   sphere { <0,0,0>, 1
     texture {
@@ -49,59 +48,54 @@
       finish {
         ambient 0
         diffuse 0
-        specular 0.85
-        roughness 0.002
-        reflection { 0.02, 0.25 fresnel on }
+        specular 1.0
+        roughness 0.0015
+        reflection { 0.04, 0.55 fresnel on }
         conserve_energy
       }
     }
     interior {
       ior 1.52
-      // Long fade settings mimic the subtle absorption in the cinematography plates.
+      // Subtle warm absorption so the orb glows from within under the key light.
       fade_power 1001
-      fade_distance 5
+      fade_distance 4
+      fade_color rgb <0.92, 0.95, 1.0>
     }
     hollow on
   }
 #end
 
 // Argument-colored cap matches the saturated stereographic disk from the film:
-// - Rainbow pigment reproduces the argument ramp.
+// - Opaque rainbow pigment reproduces the argument ramp.
 // - Grid overlay echoes the lat/long guide used to explain mappings.
+// Lower hemisphere only: clipped at y = 0 (the equator).
 #macro SphereArgumentCap(delta_lat, delta_lon, eps)
-  sphere { <0,0,0>, 1
+  sphere { <0,0,0>, 0.998
     texture {
       RainbowPigment()
       finish {
-        ambient 0
-        diffuse 0.12
-        specular 0.45
-        roughness 0.005
-        reflection 0.05
-        conserve_energy
+        ambient 0.18
+        emission 0.06
+        diffuse 0.85
+        specular 0.18
+        roughness 0.06
       }
     }
     texture {
       GridPigment(delta_lat, delta_lon, eps)
       finish {
-        ambient 0.1
-        diffuse 0.25
-        specular 0.1
-        roughness 0.015
+        ambient 0.0
+        diffuse 0.0
+        specular 0.0
       }
     }
-    interior {
-      ior 1.36
-      fade_color rgb <0.8, 0.9, 1.2>
-      fade_distance 6
-      fade_power 2
-    }
-    hollow on
-    clipped_by { plane { y, 0.8 } }  // Clipped at y = 0.8 as requested
+    clipped_by { plane { y, 0 } }
   }
 #end
 
-// Thin sheen layer adds the soft bloom present in the cinematography plates.
+// Thin sheen layer over the upper (uncolored) hemisphere: a soft warm rim
+// that nudges the orb toward the Arnold-Rogness crystal-ball look without
+// fighting the saturated argument cap below.
 #macro SphereHighlightSheen()
   sphere { <0,0,0>, 1
     texture {
@@ -109,12 +103,12 @@
       finish {
         ambient 0
         diffuse 0
-        specular 0.4
-        roughness 0.015
-        metallic 0.1
+        specular 0.55
+        roughness 0.01
+        metallic 0.12
       }
     }
-    clipped_by { plane { y, 0 } }
+    clipped_by { plane { -y, 0 } }
   }
 #end
 

--- a/assets/mobius_scene.inc
+++ b/assets/mobius_scene.inc
@@ -1,35 +1,36 @@
 // ===============================================
-// Scene Configuration for Möbius Sphere
+// Scene Configuration for Mobius Sphere
 // ===============================================
 
-// Camera setup
-#declare MobiusCamera = 
+// Camera: slightly elevated, looking down ~17 degrees with the ball centered
+// and a little headroom above for the rim highlight.
+#declare MobiusCamera =
   camera {
-    location <0, 3, -8>
-    look_at <0, 1, 0>
-    angle 35
+    location <0, 2.4, -7.5>
+    look_at <0, 0.55, 0>
+    angle 32
   }
 
-// Background color
-#declare BackgroundColor = color rgb <0.02, 0.02, 0.08>
+// Background: near-black so the lit orb pops cinematically.
+#declare BackgroundColor = color rgb <0.005, 0.006, 0.012>;
 
-// Light source at the north pole of the Möbius ball
-#declare NorthPoleLight = 
-  light_source { 
-    <0, 1.001, 0>, 
-    rgb <2.1, 2.1, 1.4> * 0.55 
-  }
+// Soft fill from camera-side, low intensity, no shadows. Gives the colored
+// lower hemisphere a gentle wash without flattening the Fresnel rim.
+light_source {
+  <-2.5, 1.4, -6.5>,
+  rgb <0.32, 0.34, 0.40>
+  shadowless
+}
 
-// Light source position marker
-#declare LightMarker = 
-  sphere {
-    <0, 1.001, 0>, 0.02
-    texture { pigment { color rgb <1,0.9,0.6> } finish { emission 1 } }
-    no_shadow
-  }
+// Cool back-rim light to lift the silhouette against the dark background.
+light_source {
+  <2.0, 0.6, 4.0>,
+  rgb <0.18, 0.22, 0.30>
+  shadowless
+}
 
 // Floor plane with checker texture
-#declare FloorPlane = 
+#declare FloorPlane =
   plane {
     y, -1
     texture { GrayCheckerFloor }

--- a/assets/mobius_template.pov
+++ b/assets/mobius_template.pov
@@ -22,30 +22,6 @@ background { BackgroundColor }
 // Use the configured floor
 object { FloorPlane }
 
-// plane { y, 0
-  //   pigment{
-    //     checker White Black
-    //     scale 0.5
-    //   }
-  // }
-
-// #declare RainbowPolar = pigment {
-  //   uv_mapping
-  //   gradient u
-  //   color_map {
-    //     [0.00 rgb <1,0,0>]
-    //     [0.16 rgb <1,1,0>]
-    //     [0.33 rgb <0,1,0>]
-    //     [0.50 rgb <0,1,1>]
-    //     [0.66 rgb <0,0,1>]
-    //     [0.83 rgb <1,0,1>]
-    //     [1.00 rgb <1,0,0>]
-    //   }
-  //   quick_color rgb <1,0.5,0>
-  // }
-
-
-
 // Compute current transform based on clock
 #if (clock <= 0.5)
   #declare CurrentTransform = transform {
@@ -63,26 +39,30 @@ object { FloorPlane }
 #declare BaseNorthPole = <0, 1.001, 0>;
 #declare CurrentNorthPole = vtransform(BaseNorthPole, CurrentTransform);
 
-// Emissive light at current north pole (using updated position)
-light_source { CurrentNorthPole, rgb <2.1, 2.1, 1.4> * 0.55 }
+// Tracked key light at the current north pole. Warm and bright so the cap
+// reads as illuminated from inside the orb, with a small fade so it does not
+// overwhelm the static fills.
+light_source {
+  CurrentNorthPole,
+  rgb <2.4, 2.2, 1.5> * 0.7
+  fade_distance 3
+  fade_power 2
+}
 
-// small visible marker for the light source
+// Small visible marker so the audience can locate the point light.
 sphere {
   CurrentNorthPole, 0.02
-  texture { pigment { color rgb <1,0.9,0.6> } finish { emission 1 } }
+  texture { pigment { color rgb <1, 0.9, 0.6> } finish { emission 1.0 } }
   no_shadow
 }
 
-// The Möbius ball - a blurry unit ball with rainbow-colored gird covering the bottom half up to 0.8 in height
+// Mobius ball: outer Fresnel glass shell, opaque rainbow argument cap on the
+// lower hemisphere (slightly inside the shell to avoid coplanar surfaces),
+// and a thin sheen on the upper hemisphere for the rim highlight.
 #declare MoebiusBall =
   union {
-    // Glass shell for the blurry effect
     SphereGlassShell()
-    
-    // Rainbow-colored gird covering the bottom half up to 0.8 in height
     SphereArgumentCap(pi/8, pi/8, 0.02)
-    
-    // Highlight sheen
     SphereHighlightSheen()
   };
 

--- a/assets/mobius_textures.inc
+++ b/assets/mobius_textures.inc
@@ -1,33 +1,38 @@
 // ===============================================
-// Textures for Möbius Sphere Scene
+// Textures for Mobius Sphere Scene
 // ===============================================
 
-// Gray checker floor texture
-#declare GrayCheckerFloor = 
+// Floor: very low-contrast dark checker with a touch of reflection so the
+// colored underside of the sphere bleeds onto the floor without distracting.
+#declare GrayCheckerFloor =
   texture {
     pigment {
       checker
-      color rgbf <0.8, 0.8, 0.8, 0.5>
-      color rgbf <0.6, 0.6, 0.6, 0.5>
-      scale 0.4
+      color rgb <0.07, 0.07, 0.085>
+      color rgb <0.04, 0.04, 0.055>
+      scale 0.6
     }
     finish {
-      ambient 0.3
-      diffuse 0.7
-      reflection 0.1
+      ambient 0.04
+      diffuse 0.55
+      specular 0.05
+      roughness 0.05
+      reflection { 0.04, 0.18 fresnel on }
+      conserve_energy
     }
   }
 
-// Rainbow pigment (argument coloring) for the Möbius ball
+// Rainbow pigment kept here for backward compatibility; the active argument
+// pigment is RainbowPigment() in mobius_macros.inc.
 #declare RainbowPolar = pigment {
   onion
   warp { spherical }
   color_map {
-    [0.00 color rgbf <0.3,0.3,1,0.5>]   // indigo
-    [0.30 color rgbf <0.0,1,0.5,0.5>]   // green
-    [0.60 color rgbf <1,0.7,0.0,0.5>]   // orange
-    [0.90 color rgbf <0.6,0.0,1,0.5>]   // violet
-    [1.00 color rgbf <0.3,0.3,1,0.5>]   // wrap back to indigo
+    [0.00 color rgb <0.3,0.3,1>]
+    [0.30 color rgb <0.0,1.0,0.5>]
+    [0.60 color rgb <1.0,0.7,0.0>]
+    [0.90 color rgb <0.6,0.0,1.0>]
+    [1.00 color rgb <0.3,0.3,1>]
   }
   scale 0.25
 }

--- a/src/Files.jl
+++ b/src/Files.jl
@@ -130,17 +130,21 @@ end
 
 """
     copy_macros(output_dir)
-"""
-function copy_macros(output_dir::String)
-    _file = "macros.inc"
-    _path = joinpath(ASSETS_DIR, _file)
-    if !isfile(_path)
-        error("Missing file: $_path")
-    end
 
-    dest_path = joinpath(output_dir, _file)
-    # Copy the shared macros file into the temporary render directory.
-    cp(_path, dest_path)
-    @debug "Copied macros file to: $dest_path"
-    return _file
+Copy every `.inc` file referenced by `mobius_template.pov` into `output_dir`
+so POV-Ray can resolve them when invoked with the temp directory as cwd.
+Any new `.inc` added to the template must be appended to `INCLUDES`.
+"""
+const INCLUDES = ("mobius_macros.inc", "mobius_textures.inc", "mobius_scene.inc")
+
+function copy_macros(output_dir::String)
+    for _file in INCLUDES
+        _path = joinpath(ASSETS_DIR, _file)
+        if !isfile(_path)
+            error("Missing file: $_path")
+        end
+        cp(_path, joinpath(output_dir, _file))
+        @debug "Copied include into render dir: $_file"
+    end
+    return INCLUDES
 end


### PR DESCRIPTION
## Summary

First iteration of the POV-Ray assets toward the look of Arnold & Rogness's *"Mobius Transformations Revealed"*: luminous crystal orb on near-black, painted lower hemisphere with a clean equator boundary.

### Wiring fixes (necessary before aesthetic iteration takes effect)

- **`copy_macros`** in `src/Files.jl` only copied `macros.inc`, but the template includes `mobius_macros.inc`, `mobius_textures.inc`, `mobius_scene.inc`. Changes to those files were not actually reaching POV-Ray's working directory. Now copies all three via a `const INCLUDES` tuple — add new `.inc` files there.
- Stripped non-ASCII (`Möbius` → `Mobius`) from the active `mobius_*.inc` files and the template, per the constraint in the brief.

### Geometry fixes

- **Argument-cap clip plane**: `y = 0.8` → `y = 0`. Previously the rainbow covered nearly the whole sphere; now it lives on the lower hemisphere only.
- **Cap radius**: `1.0` → `0.998`. The cap now sits just inside the glass shell instead of fighting it on coincident surfaces — the painted hemisphere reads as seen *through* the crystal rather than tiled with it.

### Argument coloring

- Dropped the `rgbf … 0.3` filter in favor of fully saturated opaque colors (red → yellow → green → cyan → blue → magenta → red).
- Remapped the `atan2(z,x)` lookup via `(atan2(z,x) + pi) / (2*pi)` so the wheel covers the full `color_map` `[0,1]` range.
- Cap finish reweighted toward matte-saturated (`diffuse 0.85`, `specular 0.18`) with `emission 0.06` so the colors stay readable against the near-black scene.

### Glass shell

- Stronger Fresnel reflection (`0.04 .. 0.55`) and tighter roughness for crisp rim highlights.
- Subtle warm absorption via `fade_color` for the inner-glow / crystal-orb feel.

### Lighting

- Tracked north-pole key light: warmer and brighter (`<2.4, 2.2, 1.5> * 0.7`) with `fade_distance 3` so it does not blow out the cap.
- Added a low-intensity camera-side fill and a cool back-rim light (both `shadowless`), placed inline in `mobius_scene.inc`.

### Floor & background

- Floor: very low-contrast dark checker (`<0.07>` / `<0.04>`) with Fresnel reflection so the colored underside bleeds gently onto the plane.
- Background: near-black `<0.005, 0.006, 0.012>` for the cinematic feel.

### Camera

- Slightly elevated, looking down ~17°: `location <0, 2.4, -7.5>`, `look_at <0, 0.55, 0>`, `angle 32`. Some headroom above for the rim highlight.

## Test plan

- [ ] `render_mobius_animation([0.,0.,1.], pi/4, [0.,0.,0.]; quality=:draft, nframes=4)` — confirm <30s and inspect a frame
- [ ] Visually compare against the Arnold reference: equator clean, hue wheel saturated, lat/lon grid crisp, glassy upper hemisphere with bright rim
- [ ] If happy at `:draft`, retry at `:high` (radiosity on) then `:film` (photons on)
- [ ] Note: `assets/macros.inc` is still present as an unused duplicate; can be deleted in a follow-up if desired

https://claude.ai/code/session_01LYus5hNaU3LXYjEg1Ppjvr

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYus5hNaU3LXYjEg1Ppjvr)_